### PR TITLE
Escape chapter titles in TOC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ uuid = { version = "0.8 ", features = ["v4"] }
 tempdir = { version = "0.3", optional = true } 
 zip = { version = "0.5", optional = true } 
 regex = "1"
-html2text = "0.1"
+html-escape = "0.2.6"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,11 +1,11 @@
 extern crate epub_builder;
 
 use epub_builder::EpubBuilder;
-use epub_builder::Result;
-use epub_builder::ZipLibrary;
 use epub_builder::EpubContent;
 use epub_builder::ReferenceType;
+use epub_builder::Result;
 use epub_builder::TocElement;
+use epub_builder::ZipLibrary;
 
 use std::io;
 use std::io::Write;
@@ -24,51 +24,61 @@ fn run() -> Result<()> {
 
     // Create a new EpubBuilder using the zip library
     EpubBuilder::new(ZipLibrary::new()?)?
-    // Set some metadata
+        // Set some metadata
         .metadata("author", "Joan Doe")?
         .metadata("title", "Dummy Book")?
-    // Set the stylesheet (create a "stylesheet.css" file in EPUB that is used by some generated files)
+        // Set the stylesheet (create a "stylesheet.css" file in EPUB that is used by some generated files)
         .stylesheet(dummy_css.as_bytes())?
-    // Add a image cover file
+        // Add a image cover file
         .add_cover_image("cover.png", dummy_image.as_bytes(), "image/png")?
-    // Add a resource that is not part of the linear document structure
+        // Add a resource that is not part of the linear document structure
         .add_resource("some_image.png", dummy_image.as_bytes(), "image/png")?
-    // Add a cover page
-        .add_content(EpubContent::new("cover.xhtml", dummy_content.as_bytes())
-                     .title("Cover")
-                     .reftype(ReferenceType::Cover))?
-    // Add a title page
-        .add_content(EpubContent::new("title.xhtml", dummy_content.as_bytes())
-                     .title("Title")
-                     .reftype(ReferenceType::TitlePage))?
-    // Add a chapter, mark it as beginning of the "real content"
-        .add_content(EpubContent::new("chapter_1.xhtml", dummy_content.as_bytes())
-                     .title("Chapter 1")
-                     .reftype(ReferenceType::Text))?
-    // Add a second chapter; this one has more toc information about its internal structure
-        .add_content(EpubContent::new("chapter_2.xhtml", dummy_content.as_bytes())
-                     .title("Chapter 2")
-                     .child(TocElement::new("chapter_2.xhtml#1", "Chapter 2, section 1")))?
-    // Add a section. Since its level is set to 2, it will be attached to the previous chapter.
-        .add_content(EpubContent::new("section.xhtml", dummy_content.as_bytes())
-                     .title("Chapter 2, section 2")
-                     .level(2))?
-    // Add a chapter without a title, which will thus not appear in the TOC.
+        // Add a cover page
+        .add_content(
+            EpubContent::new("cover.xhtml", dummy_content.as_bytes())
+                .title("Cover")
+                .reftype(ReferenceType::Cover),
+        )?
+        // Add a title page
+        .add_content(
+            EpubContent::new("title.xhtml", dummy_content.as_bytes())
+                .title("Title")
+                .reftype(ReferenceType::TitlePage),
+        )?
+        // Add a chapter, mark it as beginning of the "real content"
+        .add_content(
+            EpubContent::new("chapter_1.xhtml", dummy_content.as_bytes())
+                .title("Chapter 1")
+                .reftype(ReferenceType::Text),
+        )?
+        // Add a second chapter; this one has more toc information about its internal structure
+        .add_content(
+            EpubContent::new("chapter_2.xhtml", dummy_content.as_bytes())
+                .title("Chapter 2")
+                .child(TocElement::new("chapter_2.xhtml#1", "Chapter 2, section 1")),
+        )?
+        // Add a section. Since its level is set to 2, it will be attached to the previous chapter.
+        .add_content(
+            EpubContent::new("section.xhtml", dummy_content.as_bytes())
+                .title("Chapter 2, section 2")
+                .level(2),
+        )?
+        // Add a chapter without a title, which will thus not appear in the TOC.
         .add_content(EpubContent::new("notes.xhtml", dummy_content.as_bytes()))?
-    // Generate a toc inside of the document, that will be part of the linear structure.
+        // Generate a toc inside of the document, that will be part of the linear structure.
         .inline_toc()
-    // Finally, write the EPUB file to stdout
+        // Finally, write the EPUB file to stdout
         .generate(&mut io::stdout())?;
     Ok(())
 }
 
 fn main() {
     match run() {
-        Ok(_) => {
-            writeln!(&mut io::stderr(),
-                     "Successfully wrote epub document to stdout!")
-                .unwrap()
-        }
+        Ok(_) => writeln!(
+            &mut io::stderr(),
+            "Successfully wrote epub document to stdout!"
+        )
+        .unwrap(),
         Err(err) => writeln!(&mut io::stderr(), "Error: {}", err).unwrap(),
     };
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,9 +7,9 @@ use regex::Regex;
 use std::borrow::Cow;
 
 /// Escape quotes from the string
-pub fn escape_quote<'a, S:Into<Cow<'a, str>>>(s: S) -> Cow<'a, str> {
+pub fn escape_quote<'a, S: Into<Cow<'a, str>>>(s: S) -> Cow<'a, str> {
     lazy_static! {
-        static ref REGEX:Regex = Regex::new(r#"""#).unwrap();
+        static ref REGEX: Regex = Regex::new(r#"""#).unwrap();
     }
 
     let s = s.into();
@@ -21,12 +21,11 @@ pub fn escape_quote<'a, S:Into<Cow<'a, str>>>(s: S) -> Cow<'a, str> {
     }
 }
 
-
 #[test]
 fn test_escape() {
     let foo = "Some string with \"quote\"";
     assert_eq!(&escape_quote(foo), "Some string with &quot;quote&quot;");
 
-    let bar= "Some string without quote";
+    let bar = "Some string without quote";
     assert_eq!(&escape_quote(bar), bar);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
 //! A library to generate EPUB files.
 //!
 //! The purpose for this library is to make it easier to generate EPUB files:
@@ -142,44 +141,46 @@
 extern crate lazy_static;
 #[macro_use]
 extern crate error_chain;
-extern crate mustache;
 extern crate chrono;
-extern crate uuid;
+extern crate html_escape;
+extern crate mustache;
+extern crate regex;
 #[cfg(feature = "zip-command")]
 extern crate tempdir;
+extern crate uuid;
 #[cfg(feature = "zip-library")]
 extern crate zip as libzip;
-extern crate regex;
-extern crate html2text;
-#[cfg(test)] #[macro_use] extern crate pretty_assertions;
+#[cfg(test)]
+#[macro_use]
+extern crate pretty_assertions;
 
-mod errors;
+mod common;
 mod epub;
-mod zip;
+mod epub_content;
+mod errors;
 mod templates;
 mod toc;
-mod epub_content;
+mod zip;
 #[cfg(feature = "zip-command")]
 mod zip_command;
-#[cfg(feature = "zip-library")]
-mod zip_library;
 #[cfg(feature = "zip-command")]
 #[cfg(feature = "zip-library")]
 mod zip_command_or_library;
-mod common;
+#[cfg(feature = "zip-library")]
+mod zip_library;
 
-pub use errors::*;
 pub use epub::EpubBuilder;
 pub use epub::EpubVersion;
-pub use zip::Zip;
-pub use toc::Toc;
-pub use toc::TocElement;
 pub use epub_content::EpubContent;
 pub use epub_content::ReferenceType;
+pub use errors::*;
+pub use toc::Toc;
+pub use toc::TocElement;
+pub use zip::Zip;
 #[cfg(feature = "zip-command")]
 pub use zip_command::ZipCommand;
-#[cfg(feature = "zip-library")]
-pub use zip_library::ZipLibrary;
 #[cfg(feature = "zip-command")]
 #[cfg(feature = "zip-library")]
 pub use zip_command_or_library::ZipCommandOrLibrary;
+#[cfg(feature = "zip-library")]
+pub use zip_library::ZipLibrary;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -2,33 +2,32 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
 pub static IBOOKS: &'static [u8] = include_bytes!("../templates/ibooks.xml");
 pub static CONTAINER: &'static [u8] = include_bytes!("../templates/container.xml");
 
 lazy_static! {
     pub static ref TOC_NCX: ::mustache::Template =
         ::mustache::compile_str(include_str!("../templates/toc.ncx"))
-        .expect("error compiling 'toc.ncx' template'");
+            .expect("error compiling 'toc.ncx' template'");
 }
 
 pub mod v2 {
     lazy_static! {
         pub static ref CONTENT_OPF: ::mustache::Template =
             ::mustache::compile_str(include_str!("../templates/v2/content.opf"))
-            .expect("error compiling 'content.opf' (for EPUB 2.0) template");
+                .expect("error compiling 'content.opf' (for EPUB 2.0) template");
         pub static ref NAV_XHTML: ::mustache::Template =
             ::mustache::compile_str(include_str!("../templates/v2/nav.xhtml"))
-            .expect("error compiling 'nav.xhtml' (for EPUB 2.0) template");
+                .expect("error compiling 'nav.xhtml' (for EPUB 2.0) template");
     }
 }
 pub mod v3 {
     lazy_static! {
         pub static ref CONTENT_OPF: ::mustache::Template =
             ::mustache::compile_str(include_str!("../templates/v3/content.opf"))
-            .expect("error compiling 'content.opf' (for EPUB 3.0) template");
+                .expect("error compiling 'content.opf' (for EPUB 3.0) template");
         pub static ref NAV_XHTML: ::mustache::Template =
             ::mustache::compile_str(include_str!("../templates/v3/nav.xhtml"))
-            .expect("error compiling 'nav.xhtml' (for EPUB 3.0) template");
+                .expect("error compiling 'nav.xhtml' (for EPUB 3.0) template");
     }
 }

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -19,4 +19,3 @@ pub trait Zip {
     /// Generate the ZIP file
     fn generate<W: Write>(&mut self, W) -> Result<()>;
 }
-

--- a/src/zip_command_or_library.rs
+++ b/src/zip_command_or_library.rs
@@ -4,12 +4,12 @@
 
 use errors::Result;
 use zip::Zip;
-use zip_library::ZipLibrary;
 use zip_command::ZipCommand;
+use zip_library::ZipLibrary;
 
-use std::path::Path;
 use std::io::Read;
 use std::io::Write;
+use std::path::Path;
 
 /// Wrapper around either a ZipCommand or a ZipLibrary
 ///
@@ -18,15 +18,14 @@ pub enum ZipCommandOrLibrary {
     /// Command variant
     Command(ZipCommand),
     /// Library variant
-    Library(ZipLibrary)
+    Library(ZipLibrary),
 }
-
 
 impl Zip for ZipCommandOrLibrary {
     fn write_file<P: AsRef<Path>, R: Read>(&mut self, path: P, content: R) -> Result<()> {
         match self {
             ZipCommandOrLibrary::Command(ref mut command) => command.write_file(path, content),
-            ZipCommandOrLibrary::Library(ref mut library) => library.write_file(path, content)
+            ZipCommandOrLibrary::Library(ref mut library) => library.write_file(path, content),
         }
     }
 
@@ -37,18 +36,18 @@ impl Zip for ZipCommandOrLibrary {
         }
     }
 }
-                
+
 impl ZipCommandOrLibrary {
     /// Try to create a ZipCommand using `command`. If running `command` fails on the system,
     /// fall back to `ZipLibrary`.
     pub fn new(command: &str) -> Result<ZipCommandOrLibrary> {
         ZipCommand::new()
             .map(|mut z| {
-            z.command(command);
-            z})
+                z.command(command);
+                z
+            })
             .and_then(|z| z.test().map(|_| z))
             .map(|z| ZipCommandOrLibrary::Command(z))
-            .or_else(|_| ZipLibrary::new()
-                     .map(|l| ZipCommandOrLibrary::Library(l)))
+            .or_else(|_| ZipLibrary::new().map(|l| ZipCommandOrLibrary::Library(l)))
     }
 }


### PR DESCRIPTION
Solves #13, replacing the use of `html2text` with `html_escape`.

Added a test with a title with an ampersand as well.