### PR TITLE
Internal epub files generation fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["epub"]
 repository = "https://github.com/lise-henry/epub-builder/"
 documentation = "https://docs.rs/epub-builder"
 license = "MPL-2.0"
+edition = "2018"
 
 [lib]
 name = "epub_builder"
@@ -28,6 +29,8 @@ tempdir = { version = "0.3", optional = true }
 zip = { version = "0.5", optional = true } 
 regex = "1"
 html-escape = "0.2.6"
+env_logger = "0.8"
+log = "0.4"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epub-builder"
-version = "0.4.8"
+version = "0.4.9"
 authors = ["Elisabeth Henry <liz.henry@ouvaton.org>"]
 description = "A Rust library for generating EPUB files"
 readme = "README.md"

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -9,24 +9,35 @@ use epub_builder::ZipLibrary;
 
 use std::io;
 use std::io::Write;
+use std::env;
+use std::fs::File;
+#[macro_use]
+extern crate log;
 
 // Try to print Zip file to stdout
 fn run() -> Result<()> {
+    env_logger::init();
     // Some dummy content to fill our books
     let dummy_content = r#"<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
 <body>
-<p>Text of the page</p>
+<p>Text of the page<T></p>
 </body>
 </html>"#;
     let dummy_image = "Not really a PNG image";
     let dummy_css = "body { background-color: pink }";
 
+    // temp file to see epub internals
+    let _curr_dir = env::current_dir().unwrap();
+    let _out_file = _curr_dir.join("temp_epub_file.epub");
+    debug!("file to write = {}", &_out_file.display());
+    let _writer = File::create(_out_file).unwrap();
+
     // Create a new EpubBuilder using the zip library
     EpubBuilder::new(ZipLibrary::new()?)?
         // Set some metadata
         .metadata("author", "Joan Doe")?
-        .metadata("title", "Dummy Book")?
+        .metadata("title", "Dummy Book <T>")?
         // Set the stylesheet (create a "stylesheet.css" file in EPUB that is used by some generated files)
         .stylesheet(dummy_css.as_bytes())?
         // Add a image cover file
@@ -42,25 +53,25 @@ fn run() -> Result<()> {
         // Add a title page
         .add_content(
             EpubContent::new("title.xhtml", dummy_content.as_bytes())
-                .title("Title")
+                .title("Title <T>")
                 .reftype(ReferenceType::TitlePage),
         )?
         // Add a chapter, mark it as beginning of the "real content"
         .add_content(
             EpubContent::new("chapter_1.xhtml", dummy_content.as_bytes())
-                .title("Chapter 1")
+                .title("Chapter 1 <T>")
                 .reftype(ReferenceType::Text),
         )?
         // Add a second chapter; this one has more toc information about its internal structure
         .add_content(
             EpubContent::new("chapter_2.xhtml", dummy_content.as_bytes())
-                .title("Chapter 2")
+                .title("Chapter 2 <T>")
                 .child(TocElement::new("chapter_2.xhtml#1", "Chapter 2, section 1")),
         )?
         // Add a section. Since its level is set to 2, it will be attached to the previous chapter.
         .add_content(
             EpubContent::new("section.xhtml", dummy_content.as_bytes())
-                .title("Chapter 2, section 2")
+                .title("Chapter 2 <T>, section 2")
                 .level(2),
         )?
         // Add a chapter without a title, which will thus not appear in the TOC.
@@ -68,7 +79,9 @@ fn run() -> Result<()> {
         // Generate a toc inside of the document, that will be part of the linear structure.
         .inline_toc()
         // Finally, write the EPUB file to stdout
-        .generate(&mut io::stdout())?;
+        .generate(&mut io::stdout())?; // generate into stout
+        // .generate(&_writer)?; // generate into temp file to see epub internals
+    debug!("dummy book generation is done");
     Ok(())
 }
 
@@ -77,8 +90,7 @@ fn main() {
         Ok(_) => writeln!(
             &mut io::stderr(),
             "Successfully wrote epub document to stdout!"
-        )
-        .unwrap(),
+        ).unwrap(),
         Err(err) => writeln!(&mut io::stderr(), "Error: {}", err).unwrap(),
     };
 }

--- a/src/epub_content.rs
+++ b/src/epub_content.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use toc::TocElement;
+use crate::TocElement;
 
 use std::io::Read;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,8 @@ extern crate zip as libzip;
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
+#[macro_use]
+extern crate log;
 
 mod common;
 mod epub;
@@ -176,7 +178,6 @@ pub use epub_content::ReferenceType;
 pub use errors::*;
 pub use toc::Toc;
 pub use toc::TocElement;
-pub use zip::Zip;
 #[cfg(feature = "zip-command")]
 pub use zip_command::ZipCommand;
 #[cfg(feature = "zip-command")]

--- a/src/toc.rs
+++ b/src/toc.rs
@@ -155,7 +155,8 @@ impl TocElement {
         format!(
             "<li><a href=\"{link}\">{title}</a>{children}</li>\n",
             link = self.url,
-            title = self.title,
+            // escape < > symbols by &lt; &gt; using 'encode_text()' in link's Title
+            title = html_escape::encode_text(&self.title),
             children = children
         )
     }
@@ -256,7 +257,9 @@ impl Toc {
     pub fn render(&mut self, numbered: bool) -> String {
         let mut output = String::new();
         for elem in &self.elements {
-            output.push_str(&elem.render(numbered));
+            let rendered = &elem.render(numbered);
+            debug!("rendered elem: {:?}", rendered);
+            output.push_str(rendered);
         }
         format!(
             "<{oul}>\n{output}\n</{oul}>\n",

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use errors::Result;
+use crate::errors::Result;
 
 use std::io::Read;
 use std::io::Write;
@@ -17,5 +17,5 @@ pub trait Zip {
     fn write_file<P: AsRef<Path>, R: Read>(&mut self, file: P, content: R) -> Result<()>;
 
     /// Generate the ZIP file
-    fn generate<W: Write>(&mut self, W) -> Result<()>;
+    fn generate<W: Write>(&mut self, to: W) -> Result<()>;
 }

--- a/src/zip_command.rs
+++ b/src/zip_command.rs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use errors::Result;
-use errors::ResultExt;
-use zip::Zip;
+use crate::Result;
+use crate::ResultExt;
+use crate::zip::Zip;
 
 use std::fs;
 use std::fs::DirBuilder;

--- a/src/zip_command_or_library.rs
+++ b/src/zip_command_or_library.rs
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use errors::Result;
-use zip::Zip;
-use zip_command::ZipCommand;
-use zip_library::ZipLibrary;
+use crate::errors::Result;
+use crate::zip::Zip;
+use crate::ZipCommand;
+use crate::ZipLibrary;
 
 use std::io::Read;
 use std::io::Write;

--- a/src/zip_library.rs
+++ b/src/zip_library.rs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use errors::Result;
-use errors::ResultExt;
-use zip::Zip;
+use crate::Result;
+use crate::ResultExt;
+use crate::zip::Zip;
 
 use std::fmt;
 use std::io;


### PR DESCRIPTION
hi Lise

Here I'm introducing epub book generation error fixes for symbols like < > inside Titles for internal epub files:
- content.opf
- nav.xhtml
- toc.ncx
- toc.xhtml

When those symbols are not escaped in XHTML files they introduce error on opening such epub on some ebook readers.
There are two such places with that fix, see two comments in code
`// escape < > symbols by &lt; &gt; using 'encode_text()' in Title`

The rest of changes are bumping library to 'edition=2018" + adding logging for testing.
I've used those logs for analyzing in mdbook + mdbook-epub + epub-builder composed run.