### PR TITLE
Don't include deflate or bzip2 features from zip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1"
 chrono = "0.4"
 uuid = { version = "0.8 ", features = ["v4"] }
 tempdir = { version = "0.3", optional = true } 
-zip = { version = "0.5", optional = true } 
+zip = { version = "0.5", optional = true, default-features = false, features = ["time"] } 
 regex = "1"
 html-escape = "0.2.6"
 


### PR DESCRIPTION
The  default features for `zip` include `bzip2` and `deflate` but this library only uses stored compression, so there's no need to include those features.

I ran into this while compiling for arm7 (to run on remarkable e-reader), and bzip2 wouldn't compile because of some cpu feature or other. After some investigation it turned out bzip2 didn't seem to actually be needed by this library, so it seems like this won't hurt anything.