### PR TITLE
Fix empty lines and indentation of elements

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -21,6 +21,21 @@ pub fn escape_quote<'a, S: Into<Cow<'a, str>>>(s: S) -> Cow<'a, str> {
     }
 }
 
+/// Indent lines of the string
+pub fn indent<S: AsRef<str>>(s: S, level: usize) -> String {
+    s.as_ref()
+        .lines()
+        .map(|line| {
+            if !line.is_empty() {
+                format!("{:>spaces$}{}", " ", line, spaces = level * 2)
+            } else {
+                line.into()
+            }
+        })
+        .collect::<Vec<String>>()
+        .join("\n")
+}
+
 #[test]
 fn test_escape() {
     let foo = "Some string with \"quote\"";
@@ -28,4 +43,38 @@ fn test_escape() {
 
     let bar = "Some string without quote";
     assert_eq!(&escape_quote(bar), bar);
+}
+
+#[test]
+fn test_indent() {
+    let foo = "Some string with only one line";
+    assert_eq!(indent(foo, 3), "      Some string with only one line");
+
+    let bar = "1. A
+  1.1. B
+  1.2. C
+
+2. D
+
+3. E
+
+4. F
+  4.1 G
+    4.1.1 H
+  4.2 I";
+    assert_eq!(
+        indent(bar, 1),
+        "  1. A
+    1.1. B
+    1.2. C
+
+  2. D
+
+  3. E
+
+  4. F
+    4.1 G
+      4.1.1 H
+    4.2 I"
+    );
 }

--- a/templates/toc.ncx
+++ b/templates/toc.ncx
@@ -9,6 +9,6 @@
     <text>{{{toc_name}}}</text>
   </docTitle>
   <navMap>
-    {{{nav_points}}}
+{{{nav_points}}}
   </navMap>
 </ncx>

--- a/templates/v2/content.opf
+++ b/templates/v2/content.opf
@@ -7,18 +7,18 @@
     <dc:date>{{{date}}}</dc:date>
     <dc:language>{{{lang}}}</dc:language>
     <dc:creator opf:role="aut">{{{author}}}</dc:creator>
-    {{{optional}}}
+{{{optional}}}
   </metadata>
   <manifest>
-    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
-    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
-    {{{items}}}
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>
+{{{items}}}
   </manifest>
   <spine toc="ncx">
-    {{{itemrefs}}}
+{{{itemrefs}}}
   </spine>
   <guide>
-    <reference type="toc" title="{{{toc_name}}}" href="nav.xhtml" />
-    {{{guide}}}
+    <reference type="toc" title="{{{toc_name}}}" href="nav.xhtml"/>
+{{{guide}}}
   </guide>
 </package>

--- a/templates/v2/nav.xhtml
+++ b/templates/v2/nav.xhtml
@@ -11,8 +11,7 @@
 <body>
   <div id="toc">
     <h1 id="toc-title">{{{toc_name}}}</h1>
-    {{{content}}}
+{{{content}}}
   </div>
 </body>
 </html>
-

--- a/templates/v3/content.opf
+++ b/templates/v3/content.opf
@@ -7,22 +7,20 @@
     <dc:date>{{{date}}}</dc:date>
     <dc:language>{{{lang}}}</dc:language>
     <dc:creator id="epub-creator-1">{{{author}}}</dc:creator>
-    <meta refines="#epub-creator-1" property="role"
-          scheme="marc:relators">aut</meta>
+    <meta refines="#epub-creator-1" property="role" scheme="marc:relators">aut</meta>
     <meta property="dcterms:modified">{{{date}}}</meta>
-    {{{optional}}}
+{{{optional}}}
   </metadata>
   <manifest>
-    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
-    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml"
-          properties = "nav" />
-    {{{items}}}
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+{{{items}}}
   </manifest>
   <spine toc="ncx">
-    {{{itemrefs}}}
+{{{itemrefs}}}
   </spine>
   <guide>
-    <reference type="toc" title="{{{toc_name}}}" href="nav.xhtml" />
-    {{{guide}}}
+    <reference type="toc" title="{{{toc_name}}}" href="nav.xhtml"/>
+{{{guide}}}
   </guide>
 </package>

--- a/templates/v3/nav.xhtml
+++ b/templates/v3/nav.xhtml
@@ -10,11 +10,10 @@
 <body>
   <nav epub:type = "toc" id="toc">
     <h1 id="toc-title">{{{toc_name}}}</h1>
-    {{{content}}}
+{{{content}}}
   </nav>
   <nav epub:type = "landmarks">
-    {{{landmarks}}}
+{{{landmarks}}}
   </nav>
 </body>
 </html>
-


### PR DESCRIPTION
This pull request mainly does two things in template generation:
1. Properly indent elements and its children with the use of an `indent` function added to the common module and de-indenting in template files.
2. Gets rid of left over empty lines, replaces the related instances of `String` with `Vec<String>` to then join them into a `String` with the necessary amount of newlines to separate them.

Tests were modified to reflect these changes.
Also removes the extra space present in `content.opf` on the item elements.