### PR TITLE
Fix all exotic characters in IDs

### DIFF
--- a/src/epub.rs
+++ b/src/epub.rs
@@ -586,7 +586,8 @@ impl<Z: Zip> EpubBuilder<Z> {
     }
 }
 
-// generate an id compatible string, replacing / and . by _
+// generate an id compatible string, replacing all none alphanumerics to underscores
+// The actual rules for ID are here - https://www.w3.org/TR/xml-names11/#NT-NCNameChar
 fn to_id(s: &str) -> String {
-    s.replace(".", "_").replace("/", "_")
+    s.replace(|c: char| !c.is_alphanumeric(), "_")
 }


### PR DESCRIPTION
I have a source document with backslashes in the file name (windows paths). But there are also lots of other characters that would be invalid. I propose replacing all non-alphanumerics with underscores.
The full ID rules are quite complex, so this feels like a good middle ground between the current hardcoded replacements and a "proper" ruleset.