### PR TITLE
Fixing the file paths on windows

### DIFF
--- a/src/epub.rs
+++ b/src/epub.rs
@@ -427,7 +427,8 @@ impl<Z: Zip> EpubBuilder<Z> {
                 properties = properties,
                 mime = content.mime,
                 id = id,
-                href = content.file
+                // in the zip the path is always with forward slashes, on windows it is with backslashes
+                href = content.file.replace("\\", "/")
             ));
             if content.itemref {
                 itemrefs.push(format!("<itemref idref=\"{id}\"/>", id = id));


### PR DESCRIPTION
The file path on windows uses backslashes and this path is passed raw to epub-builder. Inside a zip file the paths ALWAYS use a forward slash.
This change forces the paths to use forward slashes as its the path in the zip file.