### PR TITLE
Fix multi-author tags

### DIFF
--- a/src/epub.rs
+++ b/src/epub.rs
@@ -468,8 +468,12 @@ impl<Z: Zip> EpubBuilder<Z> {
             .insert_str("lang", self.metadata.lang.as_str())
             .insert_vec("author", |builder| {
                 let mut builder = builder;
-                for author in &self.metadata.author {
-                    builder = builder.push_str(author);
+                for (i, author) in self.metadata.author.iter().enumerate() {
+                    builder = builder.push_map(|builder| {
+                        builder
+                            .insert_str("id".to_string(), i.to_string())
+                            .insert_str("name".to_string(), author)
+                    });
                 }
                 builder
             })

--- a/templates/v2/content.opf
+++ b/templates/v2/content.opf
@@ -7,7 +7,7 @@
     <dc:date>{{{date}}}</dc:date>
     <dc:language>{{{lang}}}</dc:language>
     {{#author}}
-    <dc:creator opf:role="aut">{{{.}}}</dc:creator>
+    <dc:creator opf:role="aut">{{{name}}}</dc:creator>
     {{/author}}
 {{{optional}}}
   </metadata>

--- a/templates/v3/content.opf
+++ b/templates/v3/content.opf
@@ -7,9 +7,9 @@
     <dc:date>{{{date}}}</dc:date>
     <dc:language>{{{lang}}}</dc:language>
     {{#author}}
-    <dc:creator id="epub-creator-1">{{{.}}}</dc:creator>
+    <dc:creator id="epub-creator-{{{id}}}">{{{name}}}</dc:creator>
+    <meta refines="#epub-creator-{{{id}}}" property="role" scheme="marc:relators">aut</meta>
     {{/author}}
-    <meta refines="#epub-creator-1" property="role" scheme="marc:relators">aut</meta>
     <meta property="dcterms:modified">{{{date}}}</meta>
 {{{optional}}}
   </metadata>


### PR DESCRIPTION
From Calibre: 
> The id epub-creator-1 is present on more than one element in OEBPS/content.opf. This is not allowed. Remove the id from all but one of the elements