### PR TITLE
Make date an optional value, conforming to spec

### DIFF
--- a/templates/v2/content.opf
+++ b/templates/v2/content.opf
@@ -4,7 +4,9 @@
             xmlns:opf="http://www.idpf.org/2007/opf">
     <dc:identifier id="epub-id-1">{{uuid}}</dc:identifier>
     <dc:title>{{{title}}}</dc:title>
-    <dc:date>{{{date}}}</dc:date>
+    {{#date_published}}
+    <dc:date>{{{date_published}}}</dc:date>
+    {{/date_published}}
     <dc:language>{{{lang}}}</dc:language>
     {{#author}}
     <dc:creator opf:role="aut">{{{name}}}</dc:creator>

--- a/templates/v3/content.opf
+++ b/templates/v3/content.opf
@@ -4,7 +4,9 @@
             xmlns:opf="http://www.idpf.org/2007/opf">
     <dc:identifier id="epub-id-1">{{{uuid}}}</dc:identifier>
     <dc:title>{{{title}}}</dc:title>
-    <dc:date>{{{date}}}</dc:date>
+    {{#date_published}}
+    <dc:date>{{{date_published}}}</dc:date>
+    {{/date_published}}
     <dc:language>{{{lang}}}</dc:language>
     {{#author}}
     <dc:creator id="epub-creator-{{{id}}}">{{{name}}}</dc:creator>


### PR DESCRIPTION
See: https://idpf.org/epub/30/spec/epub30-publications.html#sec-opf-dcmes-optional

"The date element must only be used to define the publication date of the EPUB Publication. The publication date is not the same as the last modified date"

Note: I added this as a DateTime variable, separate from other metadata as
1. This allows us to make sure the publication date is formatted properly
2. the user likely already has the date in a DateTime anyway

However, I'm not sure this is the best design