### PR TITLE
Enable reproducible epub generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ path = "src/lib.rs"
 [features]
 default = ["zip-command", "zip-library"]
 zip-command = ["tempdir"]
-zip-library = ["libzip"]
+# Enable `libzip` directly to avoid non-reproducible timestamps in the zip file.
+zip-library = ["libzip", "libzip/time"]
 
 [dependencies]
 eyre = "0.6.8"
@@ -26,7 +27,7 @@ once_cell = "1.13.1"
 chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }
 tempdir = { version = "0.3", optional = true } 
-libzip = { version = "0.6", optional = true, default-features = false, features = ["time", "deflate"], package = "zip"} 
+libzip = { version = "0.6", optional = true, default-features = false, features = ["deflate"], package = "zip"} 
 regex = "1"
 html-escape = "0.2.6"
 log = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,9 +138,9 @@ mod zip;
 #[cfg(feature = "zip-command")]
 mod zip_command;
 #[cfg(feature = "zip-command")]
-#[cfg(feature = "zip-library")]
+#[cfg(feature = "libzip")]
 mod zip_command_or_library;
-#[cfg(feature = "zip-library")]
+#[cfg(feature = "libzip")]
 mod zip_library;
 
 pub use epub::EpubBuilder;
@@ -152,9 +152,9 @@ pub use toc::TocElement;
 #[cfg(feature = "zip-command")]
 pub use zip_command::ZipCommand;
 #[cfg(feature = "zip-command")]
-#[cfg(feature = "zip-library")]
+#[cfg(feature = "libzip")]
 pub use zip_command_or_library::ZipCommandOrLibrary;
-#[cfg(feature = "zip-library")]
+#[cfg(feature = "libzip")]
 pub use zip_library::ZipLibrary;
 
 /// Re-exports the result type used across the library.

--- a/templates/v3/content.opf
+++ b/templates/v3/content.opf
@@ -12,7 +12,7 @@
     <dc:creator id="epub-creator-{{{id}}}">{{{name}}}</dc:creator>
     <meta refines="#epub-creator-{{{id}}}" property="role" scheme="marc:relators">aut</meta>
     {{/author}}
-    <meta property="dcterms:modified">{{{date}}}</meta>
+    <meta property="dcterms:modified">{{{date_modified}}}</meta>
 {{{optional}}}
   </metadata>
   <manifest>


### PR DESCRIPTION
I was generating some epubs and wanted the process to be reproducible.

The three places which I found to not depend strictly on user input where:
- The auto-generated `date` (also renamed to `date_modified` for clarity).
- The auto-generated `uuid`.
- Some kind of time-dependency in the zip library.
  This is solved by keeping the current features the same but allowing the user to directly enable the `libzip` library which now does not use `time` by default. Without this dependency `libzip` always produces the same output for me.

Thanks for the great library.