### PR TITLE
remove oldtime feature from chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ zip-library = ["libzip", "libzip/time"]
 eyre = "0.6.8"
 mustache = "0.9"
 once_cell = "1.13.1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }
 uuid = { version = "1", features = ["v4"] }
 tempdir = { version = "0.3", optional = true } 
 libzip = { version = "0.6", optional = true, default-features = false, features = ["deflate"], package = "zip"} 

--- a/src/zip_command.rs
+++ b/src/zip_command.rs
@@ -93,7 +93,7 @@ impl ZipCommand {
             // dir does not exist, create it
             DirBuilder::new()
                 .recursive(true)
-                .create(&dest_dir)
+                .create(dest_dir)
                 .wrap_err_with(|| {
                     format!(
                         "could not create temporary directory in {path}",


### PR DESCRIPTION
the 0.1 branch of time is deprecated, but included as a default feature of chrono. It's not used here, so this can be safely removed from the chrono dependencies.