### PR TITLE
Escape external contents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }
 tempdir = { version = "0.3", optional = true } 
 libzip = { version = "0.6", optional = true, default-features = false, features = ["deflate"], package = "zip"} 
-regex = "1"
 html-escape = "0.2.6"
 log = "0.4"
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,24 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use once_cell::sync::Lazy;
-use regex::Regex;
-
-use std::borrow::Cow;
-
-/// Escape quotes from the string
-pub fn escape_quote<'a, S: Into<Cow<'a, str>>>(s: S) -> Cow<'a, str> {
-    static REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r#"""#).expect("This is a valid regexp"));
-
-    let s = s.into();
-    if REGEX.is_match(&s) {
-        let res = REGEX.replace_all(&s, "&quot;").into_owned();
-        Cow::Owned(res)
-    } else {
-        s
-    }
-}
-
 /// Indent lines of the string
 pub fn indent<S: AsRef<str>>(s: S, level: usize) -> String {
     s.as_ref()
@@ -33,16 +15,6 @@ pub fn indent<S: AsRef<str>>(s: S, level: usize) -> String {
         })
         .collect::<Vec<String>>()
         .join("\n")
-}
-
-#[test]
-#[allow(clippy::blacklisted_name)]
-fn test_escape() {
-    let foo = "Some string with \"quote\"";
-    assert_eq!(&escape_quote(foo), "Some string with &quot;quote&quot;");
-
-    let bar = "Some string without quote";
-    assert_eq!(&escape_quote(bar), bar);
 }
 
 #[test]

--- a/src/toc.rs
+++ b/src/toc.rs
@@ -114,7 +114,6 @@ impl TocElement {
             format!("\n{}", common::indent(output.join("\n"), 1))
         };
         // Try to sanitize the escape title of all HTML elements; if it fails, insert it as is
-        let escaped_title = html_escape::encode_text(&self.title);
         (
             offset,
             format!(
@@ -125,10 +124,10 @@ impl TocElement {
   </navLabel>
   <content src=\"{url}\"/>{children}
 </navPoint>",
-                id = id,
-                title = escaped_title.trim(),
-                url = self.url,
-                children = children
+                id = html_escape::encode_double_quoted_attribute(&id.to_string()),
+                title = html_escape::encode_text(&self.title).trim(),
+                url = html_escape::encode_double_quoted_attribute(&self.url),
+                children = children, // Not escaped: XML content
             ),
         )
     }
@@ -140,11 +139,10 @@ impl TocElement {
             return String::new();
         }
         if self.children.is_empty() {
-            let escaped_title = html_escape::encode_text(&self.title);
             format!(
                 "<li><a href=\"{link}\">{title}</a></li>",
-                link = self.url,
-                title = escaped_title,
+                link = html_escape::encode_double_quoted_attribute(&self.url),
+                title = html_escape::encode_text(&self.title),
             )
         } else {
             let mut output: Vec<String> = Vec::new();
@@ -153,8 +151,8 @@ impl TocElement {
             }
             let children = format!(
                 "<{oul}>\n{children}\n</{oul}>",
-                oul = if numbered { "ol" } else { "ul" },
-                children = common::indent(output.join("\n"), 1)
+                oul = if numbered { "ol" } else { "ul" }, // Not escaped: Static string
+                children = common::indent(output.join("\n"), 1), // Not escaped: XML content
             );
             format!(
                 "\
@@ -162,10 +160,9 @@ impl TocElement {
   <a href=\"{link}\">{title}</a>
 {children}
 </li>",
-                link = self.url,
-                // escape < > symbols by &lt; &gt; using 'encode_text()' in link's Title
+                link = html_escape::encode_double_quoted_attribute(&self.url),
                 title = html_escape::encode_text(&self.title),
-                children = common::indent(children, 1)
+                children = common::indent(children, 1), // Not escaped: XML content
             )
         }
     }
@@ -272,8 +269,8 @@ impl Toc {
         common::indent(
             format!(
                 "<{oul}>\n{output}\n</{oul}>",
-                output = common::indent(output.join("\n"), 1),
-                oul = if numbered { "ol" } else { "ul" }
+                output = common::indent(output.join("\n"), 1), // Not escaped: XML content
+                oul = if numbered { "ol" } else { "ul" } // Not escaped: Static string
             ),
             2,
         )

--- a/templates/v2/content.opf
+++ b/templates/v2/content.opf
@@ -22,7 +22,7 @@
 {{{itemrefs}}}
   </spine>
   <guide>
-    <reference type="toc" title="{{{toc_name}}}" href="nav.xhtml"/>
+    <reference type="toc" title="{{{toc_name_attr}}}" href="nav.xhtml"/>
 {{{guide}}}
   </guide>
 </package>

--- a/templates/v2/nav.xhtml
+++ b/templates/v2/nav.xhtml
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta name="generator" content="{{{generator}}}" />
+  <meta name="generator" content="{{{generator_attr}}}" />
   <title>{{{toc_name}}}</title>
   <link rel="stylesheet" type="text/css" href="stylesheet.css" />
 </head>

--- a/templates/v3/content.opf
+++ b/templates/v3/content.opf
@@ -9,8 +9,8 @@
     {{/date_published}}
     <dc:language>{{{lang}}}</dc:language>
     {{#author}}
-    <dc:creator id="epub-creator-{{{id}}}">{{{name}}}</dc:creator>
-    <meta refines="#epub-creator-{{{id}}}" property="role" scheme="marc:relators">aut</meta>
+    <dc:creator id="epub-creator-{{{id_attr}}}">{{{name}}}</dc:creator>
+    <meta refines="#epub-creator-{{{id_attr}}}" property="role" scheme="marc:relators">aut</meta>
     {{/author}}
     <meta property="dcterms:modified">{{{date_modified}}}</meta>
 {{{optional}}}
@@ -24,7 +24,7 @@
 {{{itemrefs}}}
   </spine>
   <guide>
-    <reference type="toc" title="{{{toc_name}}}" href="nav.xhtml"/>
+    <reference type="toc" title="{{{toc_name_attr}}}" href="nav.xhtml"/>
 {{{guide}}}
   </guide>
 </package>

--- a/templates/v3/nav.xhtml
+++ b/templates/v3/nav.xhtml
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
 <head>
   <meta charset = "utf-8" />
-  <meta name="generator" content="{{{generator}}}" />
+  <meta name="generator" content="{{{generator_attr}}}" />
   <title>{{{toc_name}}}</title>
   <link rel="stylesheet" type="text/css" href="stylesheet.css" />
 </head>


### PR DESCRIPTION
Ideally, we would use XML builder rather than templating to avoid the need for this
but that would be require a larger rewrite. (And the only nice library I have found is https://crates.io/crates/inline-xml but that does not seem very mature – the repo link is broken). https://lib.rs/crates/tagger would probably be okay but it is deprecated.)

As a bonus, we no longer need regex dependency.
