### PR TITLE
XML element names cannot start with a number or punctuation character.

### DIFF
--- a/src/epub.rs
+++ b/src/epub.rs
@@ -777,5 +777,5 @@ fn is_id_char(c: char) -> bool {
 
 // generate an id compatible string, replacing all none ID chars to underscores
 fn to_id(s: &str) -> String {
-    s.replace(|c: char| !is_id_char(c), "_")
+    "id_".to_string() + &s.replace(|c: char| !is_id_char(c), "_")
 }


### PR DESCRIPTION
See https://www.w3.org/TR/REC-xml/#dt-name