### PR TITLE
Added `epub_direction()` (Update Page Direction using PageDirection enum instead of `metadata()`) & `add_metadata_opf()` (Add custom `<meta>` to the `content.opf` file)

### DIFF
--- a/src/epub.rs
+++ b/src/epub.rs
@@ -38,6 +38,15 @@ pub enum PageDirection {
     Rtl,
 }
 
+///
+/// 
+#[derive(Debug, Clone, Default)]
+pub struct MetadataOpf {
+    name: String,
+    content: String
+}
+
+
 impl ToString for PageDirection {
     fn to_string(&self) -> String {
         match &self {
@@ -153,7 +162,7 @@ pub struct EpubBuilder<Z: Zip> {
     stylesheet: bool,
     inline_toc: bool,
     escape_html: bool,
-    add_meta_opf: Vec<String>
+    meta_opf: Vec<MetadataOpf>
 }
 
 impl<Z: Zip> EpubBuilder<Z> {
@@ -169,7 +178,7 @@ impl<Z: Zip> EpubBuilder<Z> {
             stylesheet: false,
             inline_toc: false,
             escape_html: true,
-            add_meta_opf: vec![String::from("")]
+            meta_opf: Vec::new()
         };
 
         epub.zip
@@ -203,14 +212,17 @@ impl<Z: Zip> EpubBuilder<Z> {
     }
     
 
-    /// Add custom metadata to `content.opf`
-    ///
+    /// Add custom <meta> to `content.opf`
+    /// `self.add_metadata_opf(name, content)`
     /// 
-    /// 
+    /// ## Example
     /// e.g: <meta name="primary-writing-mode" content="vertical-rl"/>"
+    /// If you wanna add this line into `content.opf`
+    /// 
+    /// self.add_metadata_opf("primary-writing-mode", "vertical-rl")
 
-    pub fn custom_metadata_opf(&mut self, name: String, content: String) -> &mut Self {
-        self.add_meta_opf.push(format!("<meta name=\"{}\" content=\"{}\"/>", name, content));
+    pub fn add_metadata_opf(&mut self, item: MetadataOpf) -> &mut Self {
+        self.meta_opf.push(item);
         self
     }
 
@@ -576,8 +588,12 @@ impl<Z: Zip> EpubBuilder<Z> {
                 common::encode_html(rights, self.escape_html),
             ));
         }
-        for meta in &self.add_meta_opf{
-            optional.push(format!("{}", common::encode_html(meta, self.escape_html)));
+        for meta in &self.meta_opf{
+            optional.push(format!(
+                "<meta name=\"{}\" content=\"{}\"/>", 
+                common::encode_html(&meta.name, self.escape_html),
+                common::encode_html(&meta.content, self.escape_html),
+            ));
         }
 
         let date_modified = self

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -145,6 +145,7 @@ impl Content {
 #[derive(Debug)]
 pub struct EpubBuilder<Z: Zip> {
     version: EpubVersion,
+    direction: PageDirection,    
     zip: Z,
     files: Vec<Content>,
     metadata: Metadata,
@@ -159,6 +160,7 @@ impl<Z: Zip> EpubBuilder<Z> {
     pub fn new(zip: Z) -> Result<EpubBuilder<Z>> {
         let mut epub = EpubBuilder {
             version: EpubVersion::V20,
+            direction: PageDirection::Ltr,
             zip,
             files: vec![],
             metadata: Metadata::default(),
@@ -188,6 +190,16 @@ impl<Z: Zip> EpubBuilder<Z> {
         self.version = version;
         self
     }
+    
+    /// Set EPUB Direction (default: Ltr)
+    ///
+    /// * `Ltr`: Left-To-Right 
+    /// * 'Rtl`: Right-To-Left 
+    pub fn epub_direction(&mut self, direction: PageDirection) -> &mut Self {
+        self.direction = direction;
+        self
+    }
+    
 
     /// Set some EPUB metadata
     ///

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -153,6 +153,7 @@ pub struct EpubBuilder<Z: Zip> {
     stylesheet: bool,
     inline_toc: bool,
     escape_html: bool,
+    add_meta_opf: Vec<String>
 }
 
 impl<Z: Zip> EpubBuilder<Z> {
@@ -168,6 +169,7 @@ impl<Z: Zip> EpubBuilder<Z> {
             stylesheet: false,
             inline_toc: false,
             escape_html: true,
+            add_meta_opf: vec![String::from("")]
         };
 
         epub.zip
@@ -200,6 +202,17 @@ impl<Z: Zip> EpubBuilder<Z> {
         self
     }
     
+
+    /// Add custom metadata to `content.opf`
+    ///
+    /// 
+    /// 
+    /// e.g: <meta name="primary-writing-mode" content="vertical-rl"/>"
+
+    pub fn custom_metadata_opf(&mut self, name: String, content: String) -> &mut Self {
+        self.add_meta_opf.push(format!("<meta name=\"{}\" content=\"{}\"/>", name, content));
+        self
+    }
 
     /// Set some EPUB metadata
     ///
@@ -563,6 +576,10 @@ impl<Z: Zip> EpubBuilder<Z> {
                 common::encode_html(rights, self.escape_html),
             ));
         }
+        for meta in &self.add_meta_opf{
+            optional.push(format!("{}", common::encode_html(meta, self.escape_html)));
+        }
+
         let date_modified = self
             .metadata
             .date_modified

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -38,9 +38,11 @@ pub enum PageDirection {
     Rtl,
 }
 
+
+/// Represents the EPUB <meta> content inside `content.opf` file.
 ///
-/// 
-#[derive(Debug, Clone, Default)]
+/// <meta name="" content="">
+#[derive(Debug)]
 pub struct MetadataOpf {
     name: String,
     content: String
@@ -213,14 +215,18 @@ impl<Z: Zip> EpubBuilder<Z> {
     
 
     /// Add custom <meta> to `content.opf`
-    /// `self.add_metadata_opf(name, content)`
+    /// Syntax: `self.add_metadata_opf(name, content)`
     /// 
     /// ## Example
-    /// e.g: <meta name="primary-writing-mode" content="vertical-rl"/>"
-    /// If you wanna add this line into `content.opf`
+    /// If you wanna add `<meta name="primary-writing-mode" content="vertical-rl"/>` into `content.opf`
     /// 
-    /// self.add_metadata_opf("primary-writing-mode", "vertical-rl")
-
+    /// ```rust
+    /// self.add_metadata_opf(MetadataOpf {
+    ///     name: String::from("primary-writing-mode"),
+    ///     content: String::from("vertical-rl")
+    /// })
+    /// ```
+    /// 
     pub fn add_metadata_opf(&mut self, item: MetadataOpf) -> &mut Self {
         self.meta_opf.push(item);
         self

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -39,15 +39,26 @@ pub enum PageDirection {
 }
 
 
-/// Represents the EPUB <meta> content inside `content.opf` file.
+/// Represents the EPUB `<meta>` content inside `content.opf` file.
 ///
 /// <meta name="" content="">
+/// 
 #[derive(Debug)]
 pub struct MetadataOpf {
-    name: String,
-    content: String
+    /// Name of the `<meta>` tag
+    pub name: String,
+    /// Content of the `<meta>` tag
+    pub content: String
 }
 
+impl MetadataOpf {
+    /// Create new instance
+    /// 
+    /// 
+    pub fn new(&self, meta_name: String, meta_content: String) -> Self {
+        Self { name: meta_name, content: meta_content }
+    }
+}
 
 impl ToString for PageDirection {
     fn to_string(&self) -> String {
@@ -207,7 +218,9 @@ impl<Z: Zip> EpubBuilder<Z> {
     /// Set EPUB Direction (default: Ltr)
     ///
     /// * `Ltr`: Left-To-Right 
-    /// * 'Rtl`: Right-To-Left 
+    /// * `Rtl`: Right-To-Left 
+    /// 
+    /// 
     pub fn epub_direction(&mut self, direction: PageDirection) -> &mut Self {
         self.direction = direction;
         self
@@ -217,7 +230,7 @@ impl<Z: Zip> EpubBuilder<Z> {
     /// Add custom <meta> to `content.opf`
     /// Syntax: `self.add_metadata_opf(name, content)`
     /// 
-    /// ## Example
+    /// ### Example
     /// If you wanna add `<meta name="primary-writing-mode" content="vertical-rl"/>` into `content.opf`
     /// 
     /// ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ mod zip_library;
 
 pub use epub::EpubBuilder;
 pub use epub::EpubVersion;
+pub use epub::MetadataOpf;
 pub use epub::PageDirection;
 pub use epub_content::EpubContent;
 pub use epub_content::ReferenceType;


### PR DESCRIPTION
I would like to create Chinese/Japanese ebooks, which is preferably displayed vertically and from right to left. After reading the documentation, there is no convenient way to do so (I can set that manually using `metadata()` tho).

To make changing .epub direction easier, I added `epub_direction()` (Instead of having to manually set the Direction using `metadata()`).

It would be better to be able to do something like `.epub_direction(epub_builder::EpubDirection::Rtl)` instead of `.metadata("direction", "rtl")?`
