### PR TITLE
Replace the use of eyre with our own error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ zip-command = ["tempfile"]
 zip-library = ["libzip", "libzip/time"]
 
 [dependencies]
-thiserror = "1.0.64"
+thiserror = "1.0"
 once_cell = "1"
 upon = "0.7"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ zip-command = ["tempfile"]
 zip-library = ["libzip", "libzip/time"]
 
 [dependencies]
-eyre = "0.6"
+thiserror = "1.0.64"
 once_cell = "1"
 upon = "0.7"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }
 uuid = { version = "1", features = ["v4"] }
-tempfile = { version = "3", optional = true } 
-libzip = { version = "0.6", optional = true, default-features = false, features = ["deflate"], package = "zip"} 
+tempfile = { version = "3", optional = true }
+libzip = { version = "0.6", optional = true, default-features = false, features = ["deflate"], package = "zip" }
 html-escape = "0.2"
 log = "0.4"
 

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -6,7 +6,7 @@ use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 
-use eyre::Result;
+use crate::Result;
 
 /// An abstraction over possible Zip implementations.
 ///

--- a/src/zip_command_or_library.rs
+++ b/src/zip_command_or_library.rs
@@ -2,9 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use eyre::Result;
-
 use crate::zip::Zip;
+use crate::Result;
 use crate::ZipCommand;
 use crate::ZipLibrary;
 


### PR DESCRIPTION
This PR replaces the use of [`eyre`](https://crates.io/crates/eyre) with a custom error type, `crate::Error`, with the help of [`thiserror`](https://crates.io/crates/thiserror).

I was trying to include this library in my own library and encountered a bit of awkwardness regarding error handling, I hope to propose a solution that would be a bit more easy to use for other users of this lib.

Returning an `eyre::Report` in a library's public interface is also discouraged as per [`eyre`'s docs](https://docs.rs/eyre/latest/eyre/#usage-recommendations-and-stability-considerations).

There is however a major issue with this PR, as this is a breaking public API change.

Love your work, epub handling is _not_ something i want to do by hand :stuck_out_tongue:

EDIT: forgot to mention issue #30 which is heavily related.