### PR TITLE
Add support for Epub v3.3 Metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,7 @@ mod zip_library;
 pub use epub::EpubBuilder;
 pub use epub::EpubVersion;
 pub use epub::MetadataOpf;
+pub use epub::MetadataOpfV3;
 pub use epub::PageDirection;
 pub use epub_content::EpubContent;
 pub use epub_content::ReferenceType;


### PR DESCRIPTION
This is not an exhaustive implementation of everything that diffs between 3.0.1 but the main issue I've found in this library which is that the metadata format does not match.

It tries to preserve as much of the original functionality as possible by leveraging a boxed trait for the different metadata implementations which is the only way I have found to make this work without any compiler errors.

Another possible way would be to add a feature that flips the entire code, or to just abandon deprecated EPUB formats entirely and stick with the current latest.

Happy for a discussion on where this should go interface wise :)