### PR TITLE
fix(epub): add Send + Sync constraint to MetadataRenderer to maintain v0.8.0 behavior

### DIFF
--- a/src/epub.rs
+++ b/src/epub.rs
@@ -30,7 +30,7 @@ pub enum EpubVersion {
     V33,
 }
 
-pub trait MetadataRenderer {
+pub trait MetadataRenderer: Send + Sync {
     fn render_opf(&self, escape_html: bool) -> String;
 }
 


### PR DESCRIPTION

First, thanks for creating this library — it has been very helpful in building my application. I've been using it with [PyO3](https://github.com/PyO3/pyo3) since v0.8.0 or earlier, but I started encountering compilation errors when upgrading to v0.8.1.

Here's a minimal example that triggers the issue:

```rust
#[pyclass]
struct A {
    a: EpubBuilder<ZipLibrary>,
}
```

This results in the following error during compilation (which did not occur in v0.8.0):

```log
`(dyn epub_builder::epub::MetadataRenderer + 'static)` cannot be shared between threads safely [E0277]
Help: the trait `std::marker::Sync` is not implemented for `(dyn epub_builder::epub::MetadataRenderer + 'static)`
Note: required for `std::ptr::Unique<(dyn epub_builder::epub::MetadataRenderer + 'static)>` to implement `std::marker::Sync`
Note: required because it appears within the type `std::boxed::Box<(dyn epub_builder::epub::MetadataRenderer + 'static)>`
Note: required because it appears within the type `PhantomData<Box<dyn MetadataRenderer>>`
Note: required because it appears within the type `alloc::raw_vec::RawVec<std::boxed::Box<(dyn epub_builder::epub::MetadataRenderer + 'static)>>`
Note: required because it appears within the type `std::vec::Vec<std::boxed::Box<(dyn epub_builder::epub::MetadataRenderer + 'static)>>`
Note: required because it appears within the type `epub_builder::EpubBuilder<epub_builder::ZipLibrary>`
Note: required because it appears within the type `novel::A`
Note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
```

After some investigation, I found that this regression was introduced by #53, which added support for multiple metadata renderers via a trait object (`dyn MetadataRenderer`).

In v0.8.0, the field `meta_opf` had type `Vec<MetadataOpf>`, where `MetadataOpf` automatically implements both `Send` and `Sync`:

```rust
/// Represents the EPUB `<meta>` content inside the `content.opf` file.
/// 
/// <meta name="" content="">
/// 
#[derive(Debug)]
pub struct MetadataOpf {
    /// Name of the `<meta>` tag
    pub name: String,
    /// Content of the `<meta>` tag
    pub content: String,
}
```

And in `EpubBuilder`:
```rust
#[derive(Debug)]
pub struct EpubBuilder<Z: Zip> {
    version: EpubVersion,
    direction: PageDirection,    
    zip: Z,
    files: Vec<Content>,
    metadata: Metadata,
    toc: Toc,
    stylesheet: bool,
    inline_toc: bool,
    escape_html: bool,
    meta_opf: Vec<MetadataOpf>, // <-- Direct struct, Sync + Send
}
```

However, in v0.8.1, `meta_opf` was changed to `Vec<Box<dyn MetadataRenderer>>`. The `MetadataRenderer` trait does not require `Send` or `Sync`, which means types implementing it may not be thread-safe. As a result, `EpubBuilder` no longer automatically implements `Sync`, breaking compatibility with PyO3 (which requires `Sync` for shared access across Python threads).

```rust
pub trait MetadataRenderer {
    fn render_opf(&self, escape_html: bool) -> String;
}
```

```rust
#[derive(Debug)]
pub struct EpubBuilder<Z: Zip> {
    // ...
    meta_opf: Vec<Box<dyn MetadataRenderer>>, // <-- Trait object without Sync/Send
}
```

This PR fixes the issue by adding `+ Send + Sync` bounds to the `MetadataRenderer` trait:

```rust
pub trait MetadataRenderer: Send + Sync {
    fn render_opf(&self, escape_html: bool) -> String;
}
```

With this change, all implementors of `MetadataRenderer` must be `Send + Sync`, ensuring that `EpubBuilder` remains `Sync` and works correctly with PyO3 and other multi-threaded contexts.
